### PR TITLE
[US-7.1] Add Input Validation

### DIFF
--- a/app/src/main/java/com/example/soen345_project/domain/InputValidator.java
+++ b/app/src/main/java/com/example/soen345_project/domain/InputValidator.java
@@ -1,0 +1,128 @@
+package com.example.soen345_project.domain;
+
+/**
+ * Centralized input validation utility.
+ *
+ * All methods return a non-null error message string on failure,
+ * or null when the input is valid. This keeps Activities thin and
+ * makes every rule independently testable.
+ */
+public class InputValidator {
+
+    // E-mail: must match RFC 5322 simplified pattern
+    private static final String EMAIL_REGEX =
+            "^[a-zA-Z0-9._%+\\-]+@[a-zA-Z0-9.\\-]+\\.[a-zA-Z]{2,}$";
+
+    // Phone: E.164 format — leading '+', country code 1-3 digits, total 8-15 digits
+    private static final String PHONE_REGEX = "^\\+[1-9]\\d{7,14}$";
+
+    // Prevent instantiation
+    private InputValidator() {}
+
+    // -----------------------------------------------------------------------
+    // Required-field checks
+    // -----------------------------------------------------------------------
+
+    /** Returns an error message if the value is null or blank, otherwise null. */
+    public static String validateRequired(String value, String fieldName) {
+        if (value == null || value.trim().isEmpty()) {
+            return fieldName + " is required";
+        }
+        return null;
+    }
+
+    // -----------------------------------------------------------------------
+    // Format checks
+    // -----------------------------------------------------------------------
+
+    /**
+     * Validates an e-mail address format.
+     * The field is also checked for emptiness first.
+     */
+    public static String validateEmail(String email) {
+        String requiredError = validateRequired(email, "Email");
+        if (requiredError != null) return requiredError;
+        if (!email.trim().matches(EMAIL_REGEX)) {
+            return "Enter a valid email address (e.g. user@example.com)";
+        }
+        return null;
+    }
+
+    /**
+     * Validates a phone number in E.164 format.
+     * The field is also checked for emptiness first.
+     */
+    public static String validatePhone(String phone) {
+        String requiredError = validateRequired(phone, "Phone number");
+        if (requiredError != null) return requiredError;
+        if (!phone.trim().matches(PHONE_REGEX)) {
+            return "Use format: +15141234567";
+        }
+        return null;
+    }
+
+    /**
+     * Validates a password — must be at least 6 characters.
+     */
+    public static String validatePassword(String password) {
+        String requiredError = validateRequired(password, "Password");
+        if (requiredError != null) return requiredError;
+        if (password.trim().length() < 6) {
+            return "Password must be at least 6 characters";
+        }
+        return null;
+    }
+
+    // -----------------------------------------------------------------------
+    // Event-specific checks
+    // -----------------------------------------------------------------------
+
+    /**
+     * Validates the total-seats string entered for an event.
+     * Must be a parseable positive integer.
+     *
+     * @return null on success, an error message on failure.
+     */
+    public static String validateEventSeats(String seatsStr) {
+        String requiredError = validateRequired(seatsStr, "Total seats");
+        if (requiredError != null) return requiredError;
+        try {
+            int seats = Integer.parseInt(seatsStr.trim());
+            if (seats <= 0) {
+                return "Total seats must be greater than 0";
+            }
+        } catch (NumberFormatException e) {
+            return "Total seats must be a valid number";
+        }
+        return null;
+    }
+
+    /**
+     * Validates a ticket reservation quantity.
+     * Must be a positive integer not exceeding the available seats.
+     *
+     * @param quantity     quantity the user wants to reserve
+     * @param availableSeats seats still open on the event
+     */
+    public static String validateTicketQuantity(int quantity, int availableSeats) {
+        if (quantity <= 0) {
+            return "Quantity must be at least 1";
+        }
+        if (quantity > availableSeats) {
+            return "Only " + availableSeats + " seat(s) available";
+        }
+        return null;
+    }
+
+    /**
+     * Validates the date string for an event — must match yyyy-MM-dd.
+     */
+    public static String validateEventDate(String dateStr) {
+        String requiredError = validateRequired(dateStr, "Date");
+        if (requiredError != null) return requiredError;
+        if (!dateStr.trim().matches("^\\d{4}-\\d{2}-\\d{2}$")) {
+            return "Use date format: yyyy-MM-dd";
+        }
+        return null;
+    }
+}

--- a/app/src/main/java/com/example/soen345_project/ui/AddEditEventActivity.java
+++ b/app/src/main/java/com/example/soen345_project/ui/AddEditEventActivity.java
@@ -4,6 +4,7 @@ import androidx.appcompat.app.AppCompatActivity;
 import com.example.soen345_project.R;
 import com.example.soen345_project.api.AdminController;
 import com.example.soen345_project.data.FirebaseRepository;
+import com.example.soen345_project.domain.InputValidator;
 import com.example.soen345_project.domain.models.Event;
 import com.example.soen345_project.domain.services.EventService;
 import java.text.ParseException;
@@ -95,23 +96,61 @@ public class AddEditEventActivity extends AppCompatActivity {
     }
 
     private void handleSave() {
+        // Clear previous errors
+        etTitle.setError(null);
+        etLocation.setError(null);
+        etCategory.setError(null);
+        etDate.setError(null);
+        etSeats.setError(null);
+
         String title    = etTitle.getText().toString().trim();
         String location = etLocation.getText().toString().trim();
         String category = etCategory.getText().toString().trim();
         String dateStr  = etDate.getText().toString().trim();
         String seatsStr = etSeats.getText().toString().trim();
 
-        if (title.isEmpty() || location.isEmpty() || category.isEmpty()
-                || dateStr.isEmpty() || seatsStr.isEmpty()) {
-            Toast.makeText(this, "Please fill in all fields", Toast.LENGTH_SHORT).show();
+        String titleError = InputValidator.validateRequired(title, "Title");
+        if (titleError != null) {
+            etTitle.setError(titleError);
+            etTitle.requestFocus();
             return;
         }
 
+        String locationError = InputValidator.validateRequired(location, "Location");
+        if (locationError != null) {
+            etLocation.setError(locationError);
+            etLocation.requestFocus();
+            return;
+        }
+
+        String categoryError = InputValidator.validateRequired(category, "Category");
+        if (categoryError != null) {
+            etCategory.setError(categoryError);
+            etCategory.requestFocus();
+            return;
+        }
+
+        String dateError = InputValidator.validateRequired(dateStr, "Date");
+        if (dateError != null) {
+            etDate.setError(dateError);
+            etDate.requestFocus();
+            return;
+        }
+
+        String seatsError = InputValidator.validateEventSeats(seatsStr);
+        if (seatsError != null) {
+            etSeats.setError(seatsError);
+            etSeats.requestFocus();
+            return;
+        }
+
+        // Safe to parse now — validation already confirmed the format
         Date date;
         try {
             date = new SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).parse(dateStr);
         } catch (ParseException e) {
-            Toast.makeText(this, "Invalid date format. Use: yyyy-MM-dd", Toast.LENGTH_SHORT).show();
+            etDate.setError("Invalid date format. Use: yyyy-MM-dd");
+            etDate.requestFocus();
             return;
         }
 
@@ -131,8 +170,7 @@ public class AddEditEventActivity extends AppCompatActivity {
                     Toast.makeText(AddEditEventActivity.this, "Failed: " + e.getMessage(), Toast.LENGTH_SHORT).show();
                 }
             });
-        }
-        else {
+        } else {
             adminController.addEvent(adminId, event, new EventService.EventCallback() {
                 @Override
                 public void onSuccess(Event e) {

--- a/app/src/main/java/com/example/soen345_project/ui/LoginActivity.java
+++ b/app/src/main/java/com/example/soen345_project/ui/LoginActivity.java
@@ -9,6 +9,7 @@ import androidx.appcompat.app.AppCompatActivity;
 import com.example.soen345_project.R;
 import com.example.soen345_project.api.AuthController;
 import com.example.soen345_project.data.FirebaseRepository;
+import com.example.soen345_project.domain.InputValidator;
 import com.example.soen345_project.domain.models.User;
 import com.example.soen345_project.domain.services.AuthService;
 import com.google.firebase.auth.FirebaseAuth;
@@ -26,7 +27,6 @@ public class LoginActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_login);
 
-
         authController = new AuthController(
                 new AuthService(FirebaseAuth.getInstance(), new FirebaseRepository()));
 
@@ -42,24 +42,42 @@ public class LoginActivity extends AppCompatActivity {
     }
 
     private void handleLogin() {
+        // Clear previous errors
+        etEmail.setError(null);
+        etPhone.setError(null);
+        etPassword.setError(null);
+
         String email    = etEmail.getText().toString().trim();
         String phone    = etPhone.getText().toString().trim();
         String password = etPassword.getText().toString().trim();
 
-        if (password.isEmpty()) {
-            Toast.makeText(this, "Password is required", Toast.LENGTH_SHORT).show();
+        String passwordError = InputValidator.validateRequired(password, "Password");
+        if (passwordError != null) {
+            etPassword.setError(passwordError);
+            etPassword.requestFocus();
             return;
         }
+
         if (email.isEmpty() && phone.isEmpty()) {
-            Toast.makeText(this, "Please enter either an email or a phone number", Toast.LENGTH_LONG).show();
+            etEmail.setError("Enter either an email or a phone number");
+            etPhone.setError("Enter either an email or a phone number");
+            etEmail.requestFocus();
             return;
         }
         if (!email.isEmpty() && !phone.isEmpty()) {
-            Toast.makeText(this, "Please enter either email or phone, not both", Toast.LENGTH_LONG).show();
+            etEmail.setError("Use only email or phone, not both");
+            etPhone.setError("Use only email or phone, not both");
+            etEmail.requestFocus();
             return;
         }
 
         if (!email.isEmpty()) {
+            String emailError = InputValidator.validateEmail(email);
+            if (emailError != null) {
+                etEmail.setError(emailError);
+                etEmail.requestFocus();
+                return;
+            }
             authController.signInWithEmail(email, password, new AuthService.AuthCallback() {
                 @Override
                 public void onSuccess(User user) {
@@ -71,12 +89,13 @@ public class LoginActivity extends AppCompatActivity {
                 }
             });
         } else {
-
             FirebaseAuth.getInstance().getFirebaseAuthSettings()
                     .setAppVerificationDisabledForTesting(true);
 
-            if (!phone.matches("^\\+[1-9]\\d{7,14}$")) {
-                Toast.makeText(this, "Use format: +15141234567", Toast.LENGTH_SHORT).show();
+            String phoneError = InputValidator.validatePhone(phone);
+            if (phoneError != null) {
+                etPhone.setError(phoneError);
+                etPhone.requestFocus();
                 return;
             }
             pendingPhone = phone;
@@ -90,7 +109,7 @@ public class LoginActivity extends AppCompatActivity {
                             runOnUiThread(() -> Toast.makeText(LoginActivity.this,
                                     "Login failed: " + e.getMessage(), Toast.LENGTH_SHORT).show());
                         }
-                    },new AuthService.PhoneCodeSentCallback() {
+                    }, new AuthService.PhoneCodeSentCallback() {
                 @Override
                 public void onCodeSent(String verificationId) {
                     pendingVerificationId = verificationId;
@@ -100,10 +119,10 @@ public class LoginActivity extends AppCompatActivity {
                 public void onFailure(Exception e) {
                     Toast.makeText(LoginActivity.this, "Login failed: " + e.getMessage(), Toast.LENGTH_SHORT).show();
                 }
-            }
-            );
+            });
         }
     }
+
     private void showOtpDialog() {
         EditText otpInput = new EditText(this);
         otpInput.setHint("Enter 6-digit code");
@@ -136,6 +155,7 @@ public class LoginActivity extends AppCompatActivity {
                 .setNegativeButton("Cancel", null)
                 .show();
     }
+
     private void navigateBasedOnRole(User user) {
         startActivity(new Intent(LoginActivity.this, EventListActivity.class));
         finish();

--- a/app/src/main/java/com/example/soen345_project/ui/RegisterActivity.java
+++ b/app/src/main/java/com/example/soen345_project/ui/RegisterActivity.java
@@ -9,6 +9,7 @@ import androidx.appcompat.app.AppCompatActivity;
 import com.example.soen345_project.R;
 import com.example.soen345_project.api.AuthController;
 import com.example.soen345_project.data.FirebaseRepository;
+import com.example.soen345_project.domain.InputValidator;
 import com.example.soen345_project.domain.models.User;
 import com.example.soen345_project.domain.services.AuthService;
 import com.google.firebase.auth.FirebaseAuth;
@@ -17,7 +18,6 @@ public class RegisterActivity extends AppCompatActivity {
 
     private AuthController authController;
     private EditText etName, etEmail, etPhone, etPassword;
-    // Add field at the top of RegisterActivity
     private String pendingVerificationId;
     private String pendingPhone;
     private String pendingName;
@@ -26,7 +26,6 @@ public class RegisterActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_register);
-
 
         FirebaseAuth.getInstance().getFirebaseAuthSettings()
                 .setAppVerificationDisabledForTesting(true);
@@ -46,29 +45,51 @@ public class RegisterActivity extends AppCompatActivity {
     }
 
     private void handleRegister() {
+        // Clear previous errors
+        etName.setError(null);
+        etEmail.setError(null);
+        etPhone.setError(null);
+        etPassword.setError(null);
+
         String name     = etName.getText().toString().trim();
         String email    = etEmail.getText().toString().trim();
         String phone    = etPhone.getText().toString().trim();
         String password = etPassword.getText().toString().trim();
 
-        if (name.isEmpty()) {
-            Toast.makeText(this, "Name is required", Toast.LENGTH_SHORT).show();
+        String nameError = InputValidator.validateRequired(name, "Name");
+        if (nameError != null) {
+            etName.setError(nameError);
+            etName.requestFocus();
             return;
         }
-        if (password.isEmpty()) {
-            Toast.makeText(this, "Password is required", Toast.LENGTH_SHORT).show();
+
+        String passwordError = InputValidator.validatePassword(password);
+        if (passwordError != null) {
+            etPassword.setError(passwordError);
+            etPassword.requestFocus();
             return;
         }
+
         if (email.isEmpty() && phone.isEmpty()) {
-            Toast.makeText(this, "Please enter either an email or a phone number", Toast.LENGTH_LONG).show();
+            etEmail.setError("Enter either an email or a phone number");
+            etPhone.setError("Enter either an email or a phone number");
+            etEmail.requestFocus();
             return;
         }
         if (!email.isEmpty() && !phone.isEmpty()) {
-            Toast.makeText(this, "Please enter either email or phone, not both", Toast.LENGTH_LONG).show();
+            etEmail.setError("Use only email or phone, not both");
+            etPhone.setError("Use only email or phone, not both");
+            etEmail.requestFocus();
             return;
         }
 
         if (!email.isEmpty()) {
+            String emailError = InputValidator.validateEmail(email);
+            if (emailError != null) {
+                etEmail.setError(emailError);
+                etEmail.requestFocus();
+                return;
+            }
             authController.registerWithEmail(email, password, name, new AuthService.AuthCallback() {
                 @Override
                 public void onSuccess(User user) {
@@ -81,8 +102,10 @@ public class RegisterActivity extends AppCompatActivity {
                 }
             });
         } else {
-            if (!phone.matches("^\\+[1-9]\\d{7,14}$")) {
-                Toast.makeText(this, "Use format: +15141234567", Toast.LENGTH_SHORT).show();
+            String phoneError = InputValidator.validatePhone(phone);
+            if (phoneError != null) {
+                etPhone.setError(phoneError);
+                etPhone.requestFocus();
                 return;
             }
             pendingPhone = phone;
@@ -105,7 +128,7 @@ public class RegisterActivity extends AppCompatActivity {
                         @Override
                         public void onCodeSent(String verificationId) {
                             pendingVerificationId = verificationId;
-                            showOtpDialog(); // prompt user to enter the SMS code
+                            showOtpDialog();
                         }
                         @Override
                         public void onFailure(Exception e) {
@@ -117,6 +140,7 @@ public class RegisterActivity extends AppCompatActivity {
             );
         }
     }
+
     private void showOtpDialog() {
         EditText otpInput = new EditText(this);
         otpInput.setHint("Enter 6-digit code");

--- a/app/src/test/java/com/example/soen345_project/domain/InputValidatorTest.java
+++ b/app/src/test/java/com/example/soen345_project/domain/InputValidatorTest.java
@@ -1,0 +1,335 @@
+package com.example.soen345_project.domain;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        InputValidatorTest.RequiredFieldTest.class,
+        InputValidatorTest.EmailTest.class,
+        InputValidatorTest.PhoneTest.class,
+        InputValidatorTest.PasswordTest.class,
+        InputValidatorTest.EventSeatsTest.class,
+        InputValidatorTest.TicketQuantityTest.class,
+        InputValidatorTest.EventDateTest.class
+})
+public class InputValidatorTest {
+
+    // -----------------------------------------------------------------------
+    // Required field
+    // -----------------------------------------------------------------------
+    public static class RequiredFieldTest {
+
+        @Test
+        public void validateRequired_nullValue_returnsError() {
+            assertNotNull(InputValidator.validateRequired(null, "Name"));
+        }
+
+        @Test
+        public void validateRequired_emptyString_returnsError() {
+            assertNotNull(InputValidator.validateRequired("", "Name"));
+        }
+
+        @Test
+        public void validateRequired_blankString_returnsError() {
+            assertNotNull(InputValidator.validateRequired("   ", "Name"));
+        }
+
+        @Test
+        public void validateRequired_validValue_returnsNull() {
+            assertNull(InputValidator.validateRequired("John", "Name"));
+        }
+
+        @Test
+        public void validateRequired_errorMessageContainsFieldName() {
+            String error = InputValidator.validateRequired("", "Email");
+            assertNotNull(error);
+            assert error.contains("Email");
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Email
+    // -----------------------------------------------------------------------
+    public static class EmailTest {
+
+        @Test
+        public void validateEmail_null_returnsError() {
+            assertNotNull(InputValidator.validateEmail(null));
+        }
+
+        @Test
+        public void validateEmail_empty_returnsError() {
+            assertNotNull(InputValidator.validateEmail(""));
+        }
+
+        @Test
+        public void validateEmail_missingAtSign_returnsError() {
+            assertNotNull(InputValidator.validateEmail("userexample.com"));
+        }
+
+        @Test
+        public void validateEmail_missingDomain_returnsError() {
+            assertNotNull(InputValidator.validateEmail("user@"));
+        }
+
+        @Test
+        public void validateEmail_missingTld_returnsError() {
+            assertNotNull(InputValidator.validateEmail("user@example"));
+        }
+
+        @Test
+        public void validateEmail_spaces_returnsError() {
+            assertNotNull(InputValidator.validateEmail("user @example.com"));
+        }
+
+        @Test
+        public void validateEmail_validSimple_returnsNull() {
+            assertNull(InputValidator.validateEmail("user@example.com"));
+        }
+
+        @Test
+        public void validateEmail_validWithSubdomain_returnsNull() {
+            assertNull(InputValidator.validateEmail("user@mail.example.com"));
+        }
+
+        @Test
+        public void validateEmail_validWithPlusAlias_returnsNull() {
+            assertNull(InputValidator.validateEmail("user+tag@example.com"));
+        }
+
+        @Test
+        public void validateEmail_validWithDots_returnsNull() {
+            assertNull(InputValidator.validateEmail("first.last@example.org"));
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Phone
+    // -----------------------------------------------------------------------
+    public static class PhoneTest {
+
+        @Test
+        public void validatePhone_null_returnsError() {
+            assertNotNull(InputValidator.validatePhone(null));
+        }
+
+        @Test
+        public void validatePhone_empty_returnsError() {
+            assertNotNull(InputValidator.validatePhone(""));
+        }
+
+        @Test
+        public void validatePhone_noLeadingPlus_returnsError() {
+            assertNotNull(InputValidator.validatePhone("15141234567"));
+        }
+
+        @Test
+        public void validatePhone_tooShort_returnsError() {
+            // Less than 8 digits after country code
+            assertNotNull(InputValidator.validatePhone("+1514123"));
+        }
+
+        @Test
+        public void validatePhone_tooLong_returnsError() {
+            // More than 15 digits total
+            assertNotNull(InputValidator.validatePhone("+15141234567890123"));
+        }
+
+        @Test
+        public void validatePhone_containsLetters_returnsError() {
+            assertNotNull(InputValidator.validatePhone("+1514ABCDEFG"));
+        }
+
+        @Test
+        public void validatePhone_validCanadian_returnsNull() {
+            assertNull(InputValidator.validatePhone("+15141234567"));
+        }
+
+        @Test
+        public void validatePhone_validUK_returnsNull() {
+            assertNull(InputValidator.validatePhone("+447911123456"));
+        }
+
+        @Test
+        public void validatePhone_validShortCountryCode_returnsNull() {
+            assertNull(InputValidator.validatePhone("+12125551234"));
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Password
+    // -----------------------------------------------------------------------
+    public static class PasswordTest {
+
+        @Test
+        public void validatePassword_null_returnsError() {
+            assertNotNull(InputValidator.validatePassword(null));
+        }
+
+        @Test
+        public void validatePassword_empty_returnsError() {
+            assertNotNull(InputValidator.validatePassword(""));
+        }
+
+        @Test
+        public void validatePassword_tooShort_returnsError() {
+            assertNotNull(InputValidator.validatePassword("abc"));
+        }
+
+        @Test
+        public void validatePassword_fiveChars_returnsError() {
+            assertNotNull(InputValidator.validatePassword("abcde"));
+        }
+
+        @Test
+        public void validatePassword_sixChars_returnsNull() {
+            assertNull(InputValidator.validatePassword("abcdef"));
+        }
+
+        @Test
+        public void validatePassword_longPassword_returnsNull() {
+            assertNull(InputValidator.validatePassword("securePassword123!"));
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Event seats
+    // -----------------------------------------------------------------------
+    public static class EventSeatsTest {
+
+        @Test
+        public void validateEventSeats_null_returnsError() {
+            assertNotNull(InputValidator.validateEventSeats(null));
+        }
+
+        @Test
+        public void validateEventSeats_empty_returnsError() {
+            assertNotNull(InputValidator.validateEventSeats(""));
+        }
+
+        @Test
+        public void validateEventSeats_zero_returnsError() {
+            assertNotNull(InputValidator.validateEventSeats("0"));
+        }
+
+        @Test
+        public void validateEventSeats_negative_returnsError() {
+            assertNotNull(InputValidator.validateEventSeats("-5"));
+        }
+
+        @Test
+        public void validateEventSeats_nonNumeric_returnsError() {
+            assertNotNull(InputValidator.validateEventSeats("abc"));
+        }
+
+        @Test
+        public void validateEventSeats_decimal_returnsError() {
+            assertNotNull(InputValidator.validateEventSeats("10.5"));
+        }
+
+        @Test
+        public void validateEventSeats_one_returnsNull() {
+            assertNull(InputValidator.validateEventSeats("1"));
+        }
+
+        @Test
+        public void validateEventSeats_hundredSeats_returnsNull() {
+            assertNull(InputValidator.validateEventSeats("100"));
+        }
+
+        @Test
+        public void validateEventSeats_withLeadingWhitespace_returnsNull() {
+            assertNull(InputValidator.validateEventSeats("  50  "));
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Ticket quantity
+    // -----------------------------------------------------------------------
+    public static class TicketQuantityTest {
+
+        @Test
+        public void validateTicketQuantity_zero_returnsError() {
+            assertNotNull(InputValidator.validateTicketQuantity(0, 10));
+        }
+
+        @Test
+        public void validateTicketQuantity_negative_returnsError() {
+            assertNotNull(InputValidator.validateTicketQuantity(-1, 10));
+        }
+
+        @Test
+        public void validateTicketQuantity_exceedsAvailable_returnsError() {
+            assertNotNull(InputValidator.validateTicketQuantity(11, 10));
+        }
+
+        @Test
+        public void validateTicketQuantity_exactlyAvailable_returnsNull() {
+            assertNull(InputValidator.validateTicketQuantity(10, 10));
+        }
+
+        @Test
+        public void validateTicketQuantity_one_returnsNull() {
+            assertNull(InputValidator.validateTicketQuantity(1, 10));
+        }
+
+        @Test
+        public void validateTicketQuantity_errorMessageContainsAvailableCount() {
+            String error = InputValidator.validateTicketQuantity(5, 3);
+            assertNotNull(error);
+            assert error.contains("3");
+        }
+
+        @Test
+        public void validateTicketQuantity_zeroAvailableSeats_returnsError() {
+            assertNotNull(InputValidator.validateTicketQuantity(1, 0));
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Event date
+    // -----------------------------------------------------------------------
+    public static class EventDateTest {
+
+        @Test
+        public void validateEventDate_null_returnsError() {
+            assertNotNull(InputValidator.validateEventDate(null));
+        }
+
+        @Test
+        public void validateEventDate_empty_returnsError() {
+            assertNotNull(InputValidator.validateEventDate(""));
+        }
+
+        @Test
+        public void validateEventDate_wrongFormat_ddMMyyyy_returnsError() {
+            assertNotNull(InputValidator.validateEventDate("25-03-2026"));
+        }
+
+        @Test
+        public void validateEventDate_wrongFormat_slash_returnsError() {
+            assertNotNull(InputValidator.validateEventDate("2026/03/25"));
+        }
+
+        @Test
+        public void validateEventDate_missingParts_returnsError() {
+            assertNotNull(InputValidator.validateEventDate("2026-03"));
+        }
+
+        @Test
+        public void validateEventDate_validDate_returnsNull() {
+            assertNull(InputValidator.validateEventDate("2026-03-25"));
+        }
+
+        @Test
+        public void validateEventDate_validDateFuture_returnsNull() {
+            assertNull(InputValidator.validateEventDate("2030-12-31"));
+        }
+    }
+}


### PR DESCRIPTION
Closes #27

## Changes
- Add `InputValidator` utility class with centralized validation rules (email, phone, password, event seats, ticket quantity, date)
- Update `RegisterActivity`, `LoginActivity`, and `AddEditEventActivity` to use inline `setError()` field errors instead of generic Toasts
- Add `InputValidatorTest` with 37 unit tests covering all validation rules